### PR TITLE
Reorder the list of staff by status, allocation number and lastname, surname

### DIFF
--- a/src/main/java/uk/gov/justice/digital/hmpps/keyworker/model/KeyworkerStatus.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/keyworker/model/KeyworkerStatus.java
@@ -5,10 +5,10 @@ import java.util.Map;
 
 public enum KeyworkerStatus {
     ACTIVE("ACT"),
-    INACTIVE("INA"),
     UNAVAILABLE_ANNUAL_LEAVE("UAL"),
     UNAVAILABLE_LONG_TERM_ABSENCE("ULT"),
-    UNAVAILABLE_NO_PRISONER_CONTACT("UNP");
+    UNAVAILABLE_NO_PRISONER_CONTACT("UNP"),
+    INACTIVE("INA");
 
     private final String statusCode;
 

--- a/src/main/java/uk/gov/justice/digital/hmpps/keyworker/services/KeyworkerService.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/keyworker/services/KeyworkerService.java
@@ -338,7 +338,8 @@ public class KeyworkerService  {
 
         List<KeyworkerDto> keyworkers = convertedKeyworkerDtoList.stream()
                 .sorted(Comparator
-                        .comparing(KeyworkerDto::getNumberAllocated)
+                        .comparing(KeyworkerDto::getStatus)
+                        .thenComparing(KeyworkerDto::getNumberAllocated)
                         .thenComparing(KeyworkerDto::getLastName)
                         .thenComparing(KeyworkerDto::getFirstName))
                 .collect(Collectors.toList());


### PR DESCRIPTION
Change order of dropdown to show active first and inactive last.