### PR TITLE
NN-1238 Key worker stats API

### DIFF
--- a/src/main/java/uk/gov/justice/digital/hmpps/keyworker/controllers/KeyworkerServiceController.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/keyworker/controllers/KeyworkerServiceController.java
@@ -19,7 +19,6 @@ import uk.gov.justice.digital.hmpps.keyworker.services.*;
 
 import javax.persistence.EntityNotFoundException;
 import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -41,21 +40,18 @@ public class KeyworkerServiceController {
     private final UserRolesMigrationService roleMigrationService;
     private final KeyworkerAutoAllocationService keyworkerAutoAllocationService;
     private final PrisonSupportedService prisonSupportedService;
-    private final KeyworkerStatsService keyworkerStatsService;
 
     public KeyworkerServiceController(KeyworkerService keyworkerService,
                                       KeyworkerBatchService keyworkerBatchService, KeyworkerMigrationService keyworkerMigrationService,
                                       KeyworkerAutoAllocationService keyworkerAutoAllocationService,
                                       UserRolesMigrationService roleMigrationService,
-                                      PrisonSupportedService prisonSupportedService,
-                                      KeyworkerStatsService keyworkerStatsService) {
+                                      PrisonSupportedService prisonSupportedService) {
         this.keyworkerService = keyworkerService;
         this.keyworkerBatchService = keyworkerBatchService;
         this.keyworkerMigrationService = keyworkerMigrationService;
         this.keyworkerAutoAllocationService = keyworkerAutoAllocationService;
         this.roleMigrationService = roleMigrationService;
         this.prisonSupportedService = prisonSupportedService;
-        this.keyworkerStatsService = keyworkerStatsService;
     }
 
     /* --------------------------------------------------------------------------------*/
@@ -610,39 +606,6 @@ public class KeyworkerServiceController {
         }
 
         return prisonSupportedService.getPrisonDetail(prisonId);
-    }
-
-    @ApiOperation(
-            value = "Return key worker stats",
-            notes = "Can only be run with the key worker role",
-            nickname="getKeyworkerStats")
-
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "OK", response = String.class),
-            @ApiResponse(code = 400, message = "Invalid request", response = ErrorResponse.class),
-            @ApiResponse(code = 500, message = "Unrecoverable error occurred whilst processing request.", response = ErrorResponse.class) })
-
-    @GetMapping(path = "/{staffId}/prison/{prisonId}/stats")
-    public KeyworkerStatsDto getKeyworkerStats(
-            @ApiParam("staffId") @NotNull @PathVariable("staffId")
-                    Long staffId,
-
-            @ApiParam("prisonId") @NotNull @PathVariable("prisonId")
-                    String prisonId,
-
-            @ApiParam(value = "Calculate stats on or after this date (in YYYY-MM-DD format).")
-            @RequestParam(value = "fromDate")
-            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
-                    LocalDate fromDate,
-
-            @ApiParam(value = "Calculate stats on or before this date (in YYYY-MM-DD format).")
-            @RequestParam(value = "toDate")
-            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
-                    LocalDate toDate )
-    {
-
-          return keyworkerStatsService.getStatsFor(staffId, prisonId, fromDate, toDate);
-
     }
 
 }

--- a/src/main/java/uk/gov/justice/digital/hmpps/keyworker/controllers/KeyworkerStatsController.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/keyworker/controllers/KeyworkerStatsController.java
@@ -1,0 +1,62 @@
+package uk.gov.justice.digital.hmpps.keyworker.controllers;
+
+import io.swagger.annotations.*;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import uk.gov.justice.digital.hmpps.keyworker.dto.ErrorResponse;
+import uk.gov.justice.digital.hmpps.keyworker.dto.KeyworkerStatsDto;
+import uk.gov.justice.digital.hmpps.keyworker.services.KeyworkerStatsService;
+
+import javax.validation.constraints.NotNull;
+import java.time.LocalDate;
+
+@Api(tags = {"key-worker-stats"})
+
+@RestController
+@RequestMapping(
+        value="key-worker-stats",
+        produces = MediaType.APPLICATION_JSON_VALUE)
+@Slf4j
+public class KeyworkerStatsController {
+    private final KeyworkerStatsService keyworkerStatsService;
+
+    public KeyworkerStatsController(KeyworkerStatsService keyworkerStatsService) {
+        this.keyworkerStatsService = keyworkerStatsService;
+    }
+
+    @ApiOperation(
+            value = "Return key worker stats",
+            notes = "Can only be run with the key worker role",
+            nickname="getKeyworkerStats")
+
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "OK", response = String.class),
+            @ApiResponse(code = 400, message = "Invalid request", response = ErrorResponse.class),
+            @ApiResponse(code = 500, message = "Unrecoverable error occurred whilst processing request.", response = ErrorResponse.class) })
+
+    @GetMapping(path = "/{staffId}/prison/{prisonId}")
+    public KeyworkerStatsDto getKeyworkerStats(
+            @ApiParam("staffId") @NotNull @PathVariable("staffId")
+                    Long staffId,
+
+            @ApiParam("prisonId") @NotNull @PathVariable("prisonId")
+                    String prisonId,
+
+            @ApiParam(value = "Calculate stats on or after this date (in YYYY-MM-DD format).")
+            @RequestParam(value = "fromDate")
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+                    LocalDate fromDate,
+
+            @ApiParam(value = "Calculate stats on or before this date (in YYYY-MM-DD format).")
+            @RequestParam(value = "toDate")
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+                    LocalDate toDate )
+    {
+
+        return keyworkerStatsService.getStatsFor(staffId, prisonId, fromDate, toDate);
+
+    }
+
+}

--- a/src/main/java/uk/gov/justice/digital/hmpps/keyworker/dto/KeyworkerStatsDto.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/keyworker/dto/KeyworkerStatsDto.java
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.keyworker.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.annotations.ApiModel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@ApiModel(description = "KeyworkerStats")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class KeyworkerStatsDto {
+    private long caseNoteSessionCount;
+    private long caseNoteEntryCount;
+    private long projectedKeyworkerSessions;
+    private long complianceRate;
+}

--- a/src/main/java/uk/gov/justice/digital/hmpps/keyworker/services/KeyworkerStatsService.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/keyworker/services/KeyworkerStatsService.java
@@ -1,0 +1,55 @@
+package uk.gov.justice.digital.hmpps.keyworker.services;
+
+import org.apache.commons.lang3.Validate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import uk.gov.justice.digital.hmpps.keyworker.dto.CaseNoteUsageDto;
+import uk.gov.justice.digital.hmpps.keyworker.dto.KeyworkerStatsDto;
+
+import java.time.LocalDate;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+public class KeyworkerStatsService {
+    private final NomisService nomisService;
+
+    public KeyworkerStatsService(NomisService nomisService) {
+        this.nomisService = nomisService;
+    }
+
+    public KeyworkerStatsDto getStatsFor(Long staffId, String prisonId, LocalDate fromDate, LocalDate toDate) {
+
+        Validate.notNull(staffId, "staffId");
+        Validate.notNull(prisonId,"prisonId");
+        Validate.notNull(fromDate, "fromDate");
+        Validate.notNull(toDate, "toDate");
+
+        Integer caseNoteSessionCount = countCaseNotesForStaff(staffId, "KA", "KS", fromDate, toDate);
+        Integer caseNoteEntryCount = countCaseNotesForStaff(staffId, "KA", "KA", fromDate, toDate);
+
+        return KeyworkerStatsDto.builder()
+                .projectedKeyworkerSessions(0)
+                .complianceRate(0)
+                .caseNoteEntryCount(caseNoteEntryCount)
+                .caseNoteSessionCount(caseNoteSessionCount)
+                .build();
+    }
+
+    private Integer countCaseNotesForStaff(long staffId, String caseNoteType, String caseNoteSubType, LocalDate fromDate, LocalDate toDate) {
+        List<CaseNoteUsageDto> usageCounts =
+                nomisService.getCaseNoteUsage(Arrays.asList(staffId), caseNoteType, caseNoteSubType, fromDate, toDate);
+
+        Map<Long, Integer> groupedCounts =  usageCounts.stream()
+                .collect(Collectors.groupingBy(CaseNoteUsageDto::getStaffId,
+                        Collectors.summingInt(CaseNoteUsageDto::getNumCaseNotes)));
+
+        Integer result = groupedCounts.get(staffId);
+
+        if(result == null)
+            return 0;
+
+        return result;
+    }
+}

--- a/src/test/groovy/uk/gov/justice/digital/hmpps/keyworker/integration/mockApis/Elite2Api.groovy
+++ b/src/test/groovy/uk/gov/justice/digital/hmpps/keyworker/integration/mockApis/Elite2Api.groovy
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.keyworker.integration.mockApis
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule
+import groovy.json.JsonOutput
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.web.util.UriTemplate
@@ -80,6 +81,18 @@ class Elite2Api extends WireMockRule {
         stubFor(post(urlPathMatching(new UriTemplate(NOMIS_API_PREFIX + CASE_NOTE_USAGE).expand().toString()))
                 .willReturn(aResponse().withStatus(HttpStatus.OK.value())
                 .withBody(CaseNoteUsageListStub.getResponse())
+                .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+        ))
+    }
+
+    void stubCaseNoteUsageFor(int staffId, String type, String subType, String fromDate, String toDate, def response) {
+
+        def body = [staffIds: [staffId], type: type, subType: subType, fromDate: fromDate, toDate: toDate]
+
+        stubFor(post(urlPathMatching(new UriTemplate(NOMIS_API_PREFIX + CASE_NOTE_USAGE).expand().toString()))
+                .withRequestBody(equalTo(JsonOutput.toJson(body)))
+                .willReturn(aResponse().withStatus(HttpStatus.OK.value())
+                .withBody(JsonOutput.toJson(response))
                 .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
         ))
     }

--- a/src/test/groovy/uk/gov/justice/digital/hmpps/keyworker/integration/specs/KeyworkerStatsSpecification.groovy
+++ b/src/test/groovy/uk/gov/justice/digital/hmpps/keyworker/integration/specs/KeyworkerStatsSpecification.groovy
@@ -1,0 +1,53 @@
+package uk.gov.justice.digital.hmpps.keyworker.integration.specs
+
+import groovy.json.JsonSlurper
+import org.springframework.http.HttpMethod
+
+class KeyworkerStatsSpecification extends TestSpecification {
+
+    int staffId = -5
+
+    def "should get a bad request when the date parameters are missing from the request"() {
+        given:
+        migrated("LEI")
+        elite2api.stubKeyworkerDetails_basicDetailsOnly(staffId)
+
+        when: "a request for stats is made for the a member of staff"
+        def response = restTemplate.exchange("/key-worker/${staffId}/prison/LEI/stats", HttpMethod.GET, createHeaderEntity("headers"), String.class)
+
+        then: "the response status code should be 400"
+        response.statusCode.value() == 400
+    }
+
+    def "should return the correct case note counts"() {
+
+        def jsonSlurper = new JsonSlurper()
+        def fromDate = "2018-07-10"
+        def toDate = "2018-07-10"
+
+        def sessionCaseNotes = [
+                [ "staffId": staffId,"caseNoteType": "KA", "caseNoteSubType": "KS","latestCaseNote": toDate, "numCaseNotes": 3 ],
+        ]
+
+        def entryCaseNotes = [
+                [ "staffId": staffId,"caseNoteType": "KA", "caseNoteSubType": "KA","latestCaseNote": toDate, "numCaseNotes": 2 ],
+        ]
+
+        given:
+        migrated("LEI")
+        elite2api.stubKeyworkerDetails_basicDetailsOnly(staffId)
+        elite2api.stubCaseNoteUsageFor(staffId, "KA", "KS", fromDate, toDate,sessionCaseNotes)
+        elite2api.stubCaseNoteUsageFor(staffId, "KA", "KA", fromDate, toDate,entryCaseNotes)
+
+        when: "a request for stats is made for the a member of staff"
+        def response = restTemplate.exchange("/key-worker/${staffId}/prison/LEI/stats?fromDate=${fromDate}&toDate=${toDate}", HttpMethod.GET, createHeaderEntity("headers"), String.class)
+
+        then: "a count of entry and session case notes is returned"
+        def stats = jsonSlurper.parseText(response.body)
+        stats.caseNoteSessionCount == 3
+        stats.caseNoteEntryCount == 2
+        stats.projectedKeyworkerSessions == 0
+        stats.complianceRate == 0
+    }
+
+}

--- a/src/test/groovy/uk/gov/justice/digital/hmpps/keyworker/integration/specs/KeyworkerStatsSpecification.groovy
+++ b/src/test/groovy/uk/gov/justice/digital/hmpps/keyworker/integration/specs/KeyworkerStatsSpecification.groovy
@@ -13,7 +13,7 @@ class KeyworkerStatsSpecification extends TestSpecification {
         elite2api.stubKeyworkerDetails_basicDetailsOnly(staffId)
 
         when: "a request for stats is made for the a member of staff"
-        def response = restTemplate.exchange("/key-worker/${staffId}/prison/LEI/stats", HttpMethod.GET, createHeaderEntity("headers"), String.class)
+        def response = restTemplate.exchange("/key-worker-stats/${staffId}/prison/LEI", HttpMethod.GET, createHeaderEntity("headers"), String.class)
 
         then: "the response status code should be 400"
         response.statusCode.value() == 400
@@ -40,7 +40,7 @@ class KeyworkerStatsSpecification extends TestSpecification {
         elite2api.stubCaseNoteUsageFor(staffId, "KA", "KA", fromDate, toDate,entryCaseNotes)
 
         when: "a request for stats is made for the a member of staff"
-        def response = restTemplate.exchange("/key-worker/${staffId}/prison/LEI/stats?fromDate=${fromDate}&toDate=${toDate}", HttpMethod.GET, createHeaderEntity("headers"), String.class)
+        def response = restTemplate.exchange("/key-worker-stats/${staffId}/prison/LEI?fromDate=${fromDate}&toDate=${toDate}", HttpMethod.GET, createHeaderEntity("headers"), String.class)
 
         then: "a count of entry and session case notes is returned"
         def stats = jsonSlurper.parseText(response.body)

--- a/src/test/java/uk/gov/justice/digital/hmpps/keyworker/services/KeyworkerStatsServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/hmpps/keyworker/services/KeyworkerStatsServiceTest.java
@@ -1,0 +1,97 @@
+package uk.gov.justice.digital.hmpps.keyworker.services;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.justice.digital.hmpps.keyworker.dto.CaseNoteUsageDto;
+import uk.gov.justice.digital.hmpps.keyworker.dto.KeyworkerStatsDto;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+
+public class KeyworkerStatsServiceTest extends AbstractServiceTest {
+    private NomisService nomisService;
+    private KeyworkerStatsService service;
+    private LocalDate fromDate;
+    private LocalDate toDate;
+
+    private final static String TEST_AGENCY_ID = "LEI";
+    private final static Long TEST_STAFF_ID = (long) -5;
+    private final static String TEST_CASE_NOTE_TYPE = "KA";
+    private final String TEST_SESSION_CASE_NOTE_SUBTYPE = "KS";
+    private final String TEST_ENTRY_CASE_NOTE_SUBTYPE = "KA";
+
+    @Before
+    public void setUp() {
+        nomisService = mock(NomisService.class);
+        service = new KeyworkerStatsService(nomisService);
+        fromDate = LocalDate.now();
+        toDate = LocalDate.now();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testShouldThrowIfRequiredParametersAreMissing() {
+        service.getStatsFor(null, null, null, null);
+    }
+
+    @Test
+    public void testThatNomisServiceIsCalledWithTheCorrectParameters() {
+        when(nomisService.getCaseNoteUsage(
+                Collections.singletonList(TEST_STAFF_ID), TEST_CASE_NOTE_TYPE, TEST_SESSION_CASE_NOTE_SUBTYPE, fromDate,toDate))
+                    .thenReturn(new ArrayList<>());
+
+        when(nomisService.getCaseNoteUsage(
+                Collections.singletonList(TEST_STAFF_ID), TEST_CASE_NOTE_TYPE, TEST_ENTRY_CASE_NOTE_SUBTYPE, fromDate, toDate))
+                    .thenReturn(new ArrayList<>());
+
+        service.getStatsFor(TEST_STAFF_ID, TEST_AGENCY_ID, fromDate, toDate);
+
+        verify(nomisService).getCaseNoteUsage(Collections.singletonList(TEST_STAFF_ID), TEST_CASE_NOTE_TYPE,
+                TEST_SESSION_CASE_NOTE_SUBTYPE, fromDate, toDate);
+
+        verify(nomisService).getCaseNoteUsage(Collections.singletonList(TEST_STAFF_ID), TEST_CASE_NOTE_TYPE,
+                TEST_ENTRY_CASE_NOTE_SUBTYPE, fromDate, toDate);
+    }
+
+    @Test
+    public void testThatTheResponseGetsMappedCorrectly() {
+        ArrayList<CaseNoteUsageDto> sessions = new ArrayList<>();
+        ArrayList<CaseNoteUsageDto> entries = new ArrayList<>();
+
+        sessions.add(CaseNoteUsageDto.builder()
+                .caseNoteSubType(TEST_CASE_NOTE_TYPE)
+                .caseNoteSubType(TEST_SESSION_CASE_NOTE_SUBTYPE)
+                .staffId(TEST_STAFF_ID)
+                .numCaseNotes(10)
+                .build());
+
+        entries.add(CaseNoteUsageDto.builder()
+                .caseNoteSubType(TEST_CASE_NOTE_TYPE)
+                .caseNoteSubType(TEST_ENTRY_CASE_NOTE_SUBTYPE)
+                .staffId(TEST_STAFF_ID)
+                .numCaseNotes(11)
+                .build());
+
+        when(nomisService.getCaseNoteUsage(
+                Collections.singletonList(TEST_STAFF_ID), TEST_CASE_NOTE_TYPE, TEST_SESSION_CASE_NOTE_SUBTYPE, fromDate, toDate))
+                    .thenReturn(sessions);
+
+        when(nomisService.getCaseNoteUsage(
+                Collections.singletonList(TEST_STAFF_ID), TEST_CASE_NOTE_TYPE, TEST_ENTRY_CASE_NOTE_SUBTYPE, fromDate, toDate))
+                    .thenReturn(entries);
+
+        KeyworkerStatsDto stats = service.getStatsFor(
+                TEST_STAFF_ID,
+                TEST_AGENCY_ID,
+                fromDate,
+                toDate);
+
+        assertThat(stats.getCaseNoteEntryCount()).isEqualTo(11);
+        assertThat(stats.getCaseNoteSessionCount()).isEqualTo(10);
+        assertThat(stats.getComplianceRate()).isEqualTo(0);
+        assertThat(stats.getProjectedKeyworkerSessions()).isEqualTo(0);
+    }
+}


### PR DESCRIPTION
  - Create initial contract
  - Return a count of entry and session case notes

I have built the API to accept a prison id, even though it isn't used yet until the work has been completed to include it in the case notes entries. Once complete it should be a matter of adding it to the case note usage request in the nomis service.