### PR TITLE
NN-1297 (DEPENDS ON elite2api) Search URL returns records when Global Search role not enabled

### DIFF
--- a/src/main/java/uk/gov/justice/digital/hmpps/keyworker/services/KeyworkerBatchService.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/keyworker/services/KeyworkerBatchService.java
@@ -108,7 +108,7 @@ public class KeyworkerBatchService {
             final LocalDate movementDate = today.plusDays(dayNumber);
             try {
 
-                // Use custody-statuses endpoint to get info from offender_external_movements
+                // Use /movements endpoint to get info from offender_external_movements
                 // which matches when the trigger on this table fires to update offender_key_workers
 
                 final long startTime = System.currentTimeMillis();

--- a/src/main/java/uk/gov/justice/digital/hmpps/keyworker/services/NomisService.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/keyworker/services/NomisService.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 public interface NomisService {
     String URI_ACTIVE_OFFENDERS_BY_AGENCY = "/bookings?query=agencyId:eq:'{prisonId}'";
     String URI_ACTIVE_OFFENDER_BY_AGENCY = URI_ACTIVE_OFFENDERS_BY_AGENCY + "&offenderNo={offenderNo}&iepLevel=true";
-    String URI_CUSTODY_STATUSES = "/custody-statuses?fromDateTime={fromDateTime}&movementDate={movementDate}";
+    String URI_MOVEMENTS = "/movements?fromDateTime={fromDateTime}&movementDate={movementDate}";
     String URI_STAFF = "/staff/{staffId}";
     String GET_USER_DETAILS = "/users/{username}";
     String URI_AVAILABLE_KEYWORKERS = "/key-worker/{agencyId}/available";
@@ -19,7 +19,7 @@ public interface NomisService {
     String GET_STAFF_IN_SPECIFIC_PRISON = "/staff/roles/{agencyId}/role/KW";
     String CASE_NOTE_USAGE = "/case-notes/staff-usage";
     String CASE_NOTE_USAGE_BY_PRISONER = "/case-notes/usage";
-    String URI_PRISONER_LOOKUP = "/prisoners?offenderNo={offenderNo}";
+    String URI_PRISONER_LOOKUP = "/prisoners/{offenderNo}";
     String URI_CURRENT_ALLOCATIONS = "/key-worker/{agencyId}/current-allocations";
     String URI_CURRENT_ALLOCATIONS_BY_OFFENDERS = "/key-worker/{agencyId}/current-allocations/offenders";
     String URI_OFFENDERS_ALLOCATION_HISTORY = "/key-worker/offenders/allocationHistory";

--- a/src/main/java/uk/gov/justice/digital/hmpps/keyworker/services/NomisServiceImpl.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/keyworker/services/NomisServiceImpl.java
@@ -62,7 +62,7 @@ public class NomisServiceImpl implements NomisService {
 
     @Override
     public List<PrisonerCustodyStatusDto> getPrisonerStatuses(LocalDateTime threshold, LocalDate movementDate) {
-        URI uri = new UriTemplate(URI_CUSTODY_STATUSES).expand(threshold, movementDate);
+        URI uri = new UriTemplate(URI_MOVEMENTS).expand(threshold, movementDate);
 
         return restCallHelper.getForListWithAuthentication(uri, PRISONER_STATUS_DTO_LIST).getBody();
     }


### PR DESCRIPTION
Switch to use new simple endpoint which does not require global_search
Also switch batch to use /movements instead of deprecated /custody-statuses