### PR TITLE
DT-691 Apply the buffer max in memory size to all decoders

### DIFF
--- a/src/main/java/uk/gov/justice/digital/hmpps/keyworker/config/WebClientConfiguration.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/keyworker/config/WebClientConfiguration.java
@@ -13,7 +13,6 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
 import org.springframework.security.oauth2.client.web.reactive.function.client.ServletOAuth2AuthorizedClientExchangeFilterFunction;
 import org.springframework.web.reactive.function.client.ClientRequest;
 import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
-import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
 import uk.gov.justice.digital.hmpps.keyworker.utils.UserContext;
 
@@ -44,13 +43,8 @@ public class WebClientConfiguration {
     WebClient oauth2WebClient(final OAuth2AuthorizedClientManager authorizedClientManager, final WebClient.Builder builder) {
         final var oauth2Client = new ServletOAuth2AuthorizedClientExchangeFilterFunction(authorizedClientManager);
         oauth2Client.setDefaultClientRegistrationId("elite2-api");
-        final var exchangeStrategies =
-                ExchangeStrategies.builder()
-                .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(-1))
-                .build();
         return builder.baseUrl(elite2ApiRootUri)
                 .apply(oauth2Client.oauth2Configuration())
-                .exchangeStrategies(exchangeStrategies)
                 .build();
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,6 +45,9 @@ spring:
           hmpps-auth:
             token-uri: ${auth.uri.root}/oauth/token
 
+  codec:
+    max-in-memory-size: 10MB
+
 # These are needed for running locally - should be overridden by secrets when deployed with Kubernetes
 elite2api:
   client:


### PR DESCRIPTION
This was presenting in prod on Keyworker API endpoint `/key-worker/{prisonId}/offenders/unallocated`.  You can test the fix through Postman on T3.