### PR TITLE
NN-3117 env values

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -21,6 +21,7 @@ env:
   AUTH_URI_ROOT: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"
   JAVA_OPTS: "-Xmx512m"
   SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth/.well-known/jwks.json"
+  COMPLEXITY_OF_NEED_URI: "https://hmpps-complexity-of-need-staging.apps.live-1.cloud-platform.service.justice.gov.uk"
 
 whitelist:
   office: "217.33.148.210/32"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -21,6 +21,7 @@ env:
   AUTH_URI_ROOT: "https://sign-in.hmpps.service.justice.gov.uk/auth"
   JAVA_OPTS: "-Xmx512m"
   SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI: "https://sign-in.hmpps.service.justice.gov.uk/auth/.well-known/jwks.json"
+  COMPLEXITY_OF_NEED_URI: "https://hmpps-complexity-of-need-staging.apps.live-1.cloud-platform.service.justice.gov.uk"
 
 whitelist:
   office: "217.33.148.210/32"


### PR DESCRIPTION
It's mainly used to wire up the complexity service, however any requests will be ignored as it needs to have the women's state environment variable set so it won't have an impact on the previous behaviour.