### PR TITLE
MIA-503 Remove/deprecate endpoints for key worker check

### DIFF
--- a/src/main/java/uk/gov/justice/digital/hmpps/keyworker/controllers/KeyworkerStatusController.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/keyworker/controllers/KeyworkerStatusController.kt
@@ -20,6 +20,9 @@ import uk.gov.justice.digital.hmpps.keyworker.services.VerifyKeyworkerStatus
 class KeyworkerStatusController(
   private val verify: VerifyKeyworkerStatus,
 ) {
+  @Deprecated(
+    message = "Key worker job responsibility can be determined by frontend via hmpps-connect-dps-components"
+  )
   @Operation(description = "To determine if a user is a keyworker")
   @ApiResponses(
     value =

--- a/src/main/java/uk/gov/justice/digital/hmpps/keyworker/controllers/PrisonController.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/keyworker/controllers/PrisonController.kt
@@ -101,7 +101,7 @@ class PrisonController(
   @CaseloadIdHeader
   @Tag(name = MANAGE_STAFF)
   @PreAuthorize("hasRole('${Roles.ALLOCATIONS_UI}')")
-  @PutMapping("/staff/{staffId}/job-classifications", "/staff/{staffId}/job-classification")
+  @PutMapping("/staff/{staffId}/job-classifications")
   @ResponseStatus(HttpStatus.NO_CONTENT)
   fun modifyStaffJob(
     @PathVariable prisonCode: String,


### PR DESCRIPTION
MIA-503

Deprecate `GET /prisons/{prisonCode}/key-workers/{username}/status`
Remove non plural `PUT /prisons/{prisonCode}/staff/{staffId}/job-classification`