### PR TITLE
Add allocation stats to search allocatable staff endpoint

### DIFF
--- a/src/main/java/uk/gov/justice/digital/hmpps/keyworker/domain/Allocation.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/keyworker/domain/Allocation.kt
@@ -15,6 +15,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import uk.gov.justice.digital.hmpps.keyworker.config.AllocationContext
+import uk.gov.justice.digital.hmpps.keyworker.dto.ReportingPeriod
 import uk.gov.justice.digital.hmpps.keyworker.model.AllocationType
 import uk.gov.justice.digital.hmpps.keyworker.model.AllocationTypeConvertor
 import uk.gov.justice.digital.hmpps.keyworker.utils.IdGenerator.newUuid
@@ -73,6 +74,12 @@ class Allocation(
     this.deallocationReason = deallocationReason
   }
 }
+
+fun List<Allocation>.filterApplicable(reportingPeriod: ReportingPeriod) =
+  filter {
+    (it.deallocatedAt == null || !it.deallocatedAt!!.isBefore(reportingPeriod.from)) &&
+      it.allocatedAt.isBefore(reportingPeriod.to)
+  }
 
 interface StaffAllocationRepository : JpaRepository<Allocation, UUID> {
   @Query(
@@ -135,6 +142,20 @@ interface StaffAllocationRepository : JpaRepository<Allocation, UUID> {
   fun findActiveForPrisonStaffBetween(
     prisonCode: String,
     staffId: Long,
+    fromDate: LocalDateTime,
+    toDate: LocalDateTime,
+  ): List<Allocation>
+
+  @Query(
+    """
+      select sa from Allocation sa
+      where sa.staffId in :staffIds and sa.prisonCode = :prisonCode
+      and sa.allocatedAt <= :toDate and (sa.deallocatedAt is null or sa.deallocatedAt >= :fromDate)
+    """,
+  )
+  fun findActiveForPrisonStaffBetween(
+    prisonCode: String,
+    staffIds: Set<Long>,
     fromDate: LocalDateTime,
     toDate: LocalDateTime,
   ): List<Allocation>

--- a/src/main/java/uk/gov/justice/digital/hmpps/keyworker/dto/AllocatableStaffSearch.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/keyworker/dto/AllocatableStaffSearch.kt
@@ -17,7 +17,6 @@ data class AllocatableSummary(
   val capacity: Int,
   val allocated: Int,
   val allowAutoAllocation: Boolean,
-  val numberOfSessions: Int,
-  val numberOfEntries: Int,
   val staffRole: StaffRoleInfo,
+  val stats: StaffCountStats,
 )

--- a/src/main/java/uk/gov/justice/digital/hmpps/keyworker/integration/ManageUsersApiClient.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/keyworker/integration/ManageUsersApiClient.kt
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.bodyToFlux
 import org.springframework.web.reactive.function.client.bodyToMono
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
@@ -22,7 +23,14 @@ class ManageUsersClient(
     } else {
       Flux
         .fromIterable(usernames)
-        .flatMap({ getUserDetailsMono(it) }, 10)
+        .flatMap({
+          webClient
+            .get()
+            .uri("/users/{username}", it)
+            .retrieve()
+            .bodyToFlux<UserDetails>()
+            .retryRequestOnTransientException()
+        }, 10)
         .collectList()
         .block()!! + UserDetails(SYSTEM_USERNAME, true, "Sys", "DPS", "0", null, null)
     }

--- a/src/main/java/uk/gov/justice/digital/hmpps/keyworker/integration/RetryWebClientException.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/keyworker/integration/RetryWebClientException.kt
@@ -2,11 +2,23 @@ package uk.gov.justice.digital.hmpps.keyworker.integration
 
 import org.springframework.web.reactive.function.client.WebClientRequestException
 import org.springframework.web.reactive.function.client.WebClientResponseException
+import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.util.retry.Retry
 import java.time.Duration
 
 fun <T> Mono<T>.retryRequestOnTransientException(): Mono<T> =
+  retryWhen(
+    Retry
+      .backoff(3, Duration.ofMillis(250))
+      .filter {
+        it is WebClientRequestException || (it is WebClientResponseException && it.statusCode.is5xxServerError)
+      }.onRetryExhaustedThrow { _, signal ->
+        signal.failure()
+      },
+  )
+
+fun <T> Flux<T>.retryRequestOnTransientException(): Flux<T> =
   retryWhen(
     Retry
       .backoff(3, Duration.ofMillis(250))

--- a/src/main/java/uk/gov/justice/digital/hmpps/keyworker/integration/casenotes/CaseNotesApiClient.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/keyworker/integration/casenotes/CaseNotesApiClient.kt
@@ -5,7 +5,9 @@ import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.BodyInserters.fromValue
 import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.bodyToFlux
 import org.springframework.web.reactive.function.client.bodyToMono
+import reactor.core.publisher.Flux
 import uk.gov.justice.digital.hmpps.keyworker.integration.retryRequestOnTransientException
 import java.util.UUID
 
@@ -24,6 +26,24 @@ class CaseNotesApiClient(
           else -> res.createError()
         }
       }.retryRequestOnTransientException()
+      .block()!!
+
+  fun getUsageByPersonIdentifiers(
+    requests: List<UsageByPersonIdentifierRequest>,
+  ): List<Pair<UsageByPersonIdentifierRequest, NoteUsageResponse<UsageByPersonIdentifierResponse>>> =
+    Flux
+      .fromIterable(requests)
+      .flatMap({
+        webClient
+          .post()
+          .uri("/case-notes/usage")
+          .bodyValue(it)
+          .retrieve()
+          .bodyToFlux<NoteUsageResponse<UsageByPersonIdentifierResponse>>()
+          .retryRequestOnTransientException()
+          .map { res -> Pair(it, res) }
+      }, 10)
+      .collectList()
       .block()!!
 
   fun getUsageByStaffIds(usage: UsageByAuthorIdRequest): NoteUsageResponse<UsageByAuthorIdResponse> =

--- a/src/main/java/uk/gov/justice/digital/hmpps/keyworker/integration/casenotes/CaseNotesUsage.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/keyworker/integration/casenotes/CaseNotesUsage.kt
@@ -187,4 +187,16 @@ data class CaseNoteSummary(
       .filter { it.subType == KW_SESSION_SUBTYPE }
       .map { it.personIdentifier }
       .toSet()
+
+  companion object {
+    fun emptyEvents(policy: AllocationPolicy) =
+      when (policy) {
+        AllocationPolicy.KEY_WORKER ->
+          listOf(
+            RecordedEventCount(SESSION, 0),
+            RecordedEventCount(ENTRY, 0),
+          )
+        AllocationPolicy.PERSONAL_OFFICER -> listOf(RecordedEventCount(ENTRY, 0))
+      }
+  }
 }

--- a/src/main/java/uk/gov/justice/digital/hmpps/keyworker/services/GetStaffDetails.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/keyworker/services/GetStaffDetails.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.keyworker.domain.StaffConfigRepository
 import uk.gov.justice.digital.hmpps.keyworker.domain.StaffRole
 import uk.gov.justice.digital.hmpps.keyworker.domain.StaffRoleRepository
 import uk.gov.justice.digital.hmpps.keyworker.domain.asCodedDescription
+import uk.gov.justice.digital.hmpps.keyworker.domain.filterApplicable
 import uk.gov.justice.digital.hmpps.keyworker.domain.of
 import uk.gov.justice.digital.hmpps.keyworker.domain.toKeyworkerStatusCodedDescription
 import uk.gov.justice.digital.hmpps.keyworker.dto.CodedDescription
@@ -188,11 +189,7 @@ class GetStaffDetails(
     staffId: Long,
   ): Pair<StaffCountStats, CaseNoteSummary?> {
     val context = AllocationContext.get()
-    val applicableAllocations =
-      filter {
-        (it.deallocatedAt == null || !it.deallocatedAt!!.isBefore(reportingPeriod.from)) &&
-          it.allocatedAt.isBefore(reportingPeriod.to)
-      }
+    val applicableAllocations = filterApplicable(reportingPeriod)
     val personIdentifiers = applicableAllocations.map { it.personIdentifier }.toSet()
     val cnSummary =
       if (personIdentifiers.isEmpty()) {

--- a/src/main/java/uk/gov/justice/digital/hmpps/keyworker/services/GetStaffDetails.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/keyworker/services/GetStaffDetails.kt
@@ -40,7 +40,7 @@ import uk.gov.justice.digital.hmpps.keyworker.integration.prisonersearch.Prisone
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit.DAYS
-import kotlin.math.round
+import kotlin.math.floor
 import uk.gov.justice.digital.hmpps.keyworker.dto.Allocation as AllocationModel
 import uk.gov.justice.digital.hmpps.keyworker.dto.Prisoner as Person
 
@@ -231,7 +231,7 @@ fun List<Allocation>.staffCountStatsFromApplicableAllocations(
     if (count() > 0) {
       val sessionPerDay = 1 / (prisonConfig.frequencyInWeeks * 7.0)
       sumOf {
-        round(it.daysAllocatedForStats(reportingPeriod) * sessionPerDay).toInt()
+        floor(it.daysAllocatedForStats(reportingPeriod) * sessionPerDay + 0.5).toInt()
       }
     } else {
       0

--- a/src/main/java/uk/gov/justice/digital/hmpps/keyworker/services/GetStaffDetails.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/keyworker/services/GetStaffDetails.kt
@@ -29,6 +29,7 @@ import uk.gov.justice.digital.hmpps.keyworker.dto.StaffSummary
 import uk.gov.justice.digital.hmpps.keyworker.integration.PrisonApiClient
 import uk.gov.justice.digital.hmpps.keyworker.integration.Prisoner
 import uk.gov.justice.digital.hmpps.keyworker.integration.casenotes.CaseNoteSummary
+import uk.gov.justice.digital.hmpps.keyworker.integration.casenotes.CaseNoteSummary.Companion.emptyEvents
 import uk.gov.justice.digital.hmpps.keyworker.integration.casenotes.CaseNotesApiClient
 import uk.gov.justice.digital.hmpps.keyworker.integration.casenotes.UsageByPersonIdentifierRequest.Companion.keyworkerTypes
 import uk.gov.justice.digital.hmpps.keyworker.integration.casenotes.UsageByPersonIdentifierRequest.Companion.personalOfficerTypes
@@ -37,7 +38,6 @@ import uk.gov.justice.digital.hmpps.keyworker.integration.getRelevantAlertCodes
 import uk.gov.justice.digital.hmpps.keyworker.integration.getRemainingAlertCount
 import uk.gov.justice.digital.hmpps.keyworker.integration.prisonersearch.PrisonerSearchClient
 import java.time.LocalDate
-import java.time.LocalDate.now
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit.DAYS
 import kotlin.math.round
@@ -82,7 +82,7 @@ class GetStaffDetails(
     from: LocalDate?,
     to: LocalDate?,
   ): StaffDetails {
-    val statsReportingPeriod =
+    val reportingPeriod =
       if (from != null && to != null) {
         ReportingPeriod(from.atStartOfDay(), to.plusDays(1).atStartOfDay())
       } else {
@@ -104,15 +104,13 @@ class GetStaffDetails(
 
     val prisonConfig = prisonConfigRepository.findByCode(prisonCode) ?: PrisonConfiguration.default(prisonCode)
 
-    val fromDate = now().minusMonths(1)
-    val previousFromDate = fromDate.minusMonths(1)
     val staffInfo = staffConfigRepository.findAllWithAllocationCount(prisonCode, setOf(staffId)).firstOrNull()
     val allAllocations =
       allocationRepository.findActiveForPrisonStaffBetween(
         prisonCode,
         staffId,
-        previousFromDate.atStartOfDay(),
-        now().atStartOfDay().plusDays(1),
+        reportingPeriod.from,
+        reportingPeriod.to,
       )
     val activeAllocations = allAllocations.filter { it.isActive }
     val prisonerDetails =
@@ -127,9 +125,9 @@ class GetStaffDetails(
     val prisonName =
       prisonerDetails.values.firstOrNull()?.prisonName ?: prisonRegisterApi.findPrison(prisonCode)!!.prisonName
 
-    val (current, cnSummary) = allAllocations.staffCountStats(statsReportingPeriod, prisonConfig, staffId)
+    val (current, cnSummary) = allAllocations.staffCountStats(reportingPeriod, prisonConfig, staffId)
     val (previous, _) =
-      allAllocations.staffCountStats(statsReportingPeriod.previousPeriod(), prisonConfig, staffId)
+      allAllocations.staffCountStats(reportingPeriod.previousPeriod(), prisonConfig, staffId)
 
     val staff = staffWithRole.first
     return StaffDetails(
@@ -215,37 +213,47 @@ class GetStaffDetails(
             },
           ).summary()
       }
-    val projectedSessions =
-      if (count() > 0) {
-        val sessionPerDay = 1 / (prisonConfig.frequencyInWeeks * 7.0)
-        applicableAllocations.sumOf {
-          round(it.daysAllocatedForStats(reportingPeriod) * sessionPerDay).toInt()
-        }
-      } else {
-        0
-      }
-    val compliance =
-      if (projectedSessions == 0 || cnSummary == null) {
-        null
-      } else {
-        Statistic.percentage(
-          cnSummary.totalComplianceEvents(context.policy),
-          projectedSessions,
-        )
-      }
 
     return Pair(
-      StaffCountStats(
-        reportingPeriod.from.toLocalDate(),
-        reportingPeriod.to.toLocalDate().minusDays(1),
-        projectedSessions,
-        cnSummary?.totalComplianceEvents(context.policy) ?: 0,
-        cnSummary?.countEvents(context.policy) ?: listOf(),
-        compliance ?: 0.0,
-      ),
+      applicableAllocations.staffCountStatsFromApplicableAllocations(reportingPeriod, prisonConfig, cnSummary),
       cnSummary,
     )
   }
+}
+
+fun List<Allocation>.staffCountStatsFromApplicableAllocations(
+  reportingPeriod: ReportingPeriod,
+  prisonConfig: PrisonConfiguration,
+  cnSummary: CaseNoteSummary?,
+): StaffCountStats {
+  val context = AllocationContext.get()
+  val projectedSessions =
+    if (count() > 0) {
+      val sessionPerDay = 1 / (prisonConfig.frequencyInWeeks * 7.0)
+      sumOf {
+        round(it.daysAllocatedForStats(reportingPeriod) * sessionPerDay).toInt()
+      }
+    } else {
+      0
+    }
+  val compliance =
+    if (projectedSessions == 0 || cnSummary == null) {
+      null
+    } else {
+      Statistic.percentage(
+        cnSummary.totalComplianceEvents(context.policy),
+        projectedSessions,
+      )
+    }
+
+  return StaffCountStats(
+    reportingPeriod.from.toLocalDate(),
+    reportingPeriod.to.toLocalDate().minusDays(1),
+    projectedSessions,
+    cnSummary?.totalComplianceEvents(context.policy) ?: 0,
+    cnSummary?.countEvents(context.policy) ?: emptyEvents(context.policy),
+    compliance ?: 0.0,
+  )
 }
 
 private fun Prisoner.asPrisoner() =

--- a/src/main/java/uk/gov/justice/digital/hmpps/keyworker/services/StaffSearch.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/keyworker/services/StaffSearch.kt
@@ -3,12 +3,14 @@ package uk.gov.justice.digital.hmpps.keyworker.services
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.keyworker.config.AllocationContext
 import uk.gov.justice.digital.hmpps.keyworker.config.AllocationPolicy
+import uk.gov.justice.digital.hmpps.keyworker.domain.Allocation
 import uk.gov.justice.digital.hmpps.keyworker.domain.PrisonConfiguration
 import uk.gov.justice.digital.hmpps.keyworker.domain.PrisonConfigurationRepository
 import uk.gov.justice.digital.hmpps.keyworker.domain.ReferenceData
 import uk.gov.justice.digital.hmpps.keyworker.domain.ReferenceDataDomain
 import uk.gov.justice.digital.hmpps.keyworker.domain.ReferenceDataKey
 import uk.gov.justice.digital.hmpps.keyworker.domain.ReferenceDataRepository
+import uk.gov.justice.digital.hmpps.keyworker.domain.StaffAllocationRepository
 import uk.gov.justice.digital.hmpps.keyworker.domain.StaffConfigRepository
 import uk.gov.justice.digital.hmpps.keyworker.domain.StaffRole
 import uk.gov.justice.digital.hmpps.keyworker.domain.StaffRoleRepository
@@ -21,6 +23,7 @@ import uk.gov.justice.digital.hmpps.keyworker.dto.AllocatableStaff
 import uk.gov.justice.digital.hmpps.keyworker.dto.AllocatableSummary
 import uk.gov.justice.digital.hmpps.keyworker.dto.CodedDescription
 import uk.gov.justice.digital.hmpps.keyworker.dto.NomisStaffRole
+import uk.gov.justice.digital.hmpps.keyworker.dto.ReportingPeriod
 import uk.gov.justice.digital.hmpps.keyworker.dto.StaffRoleInfo
 import uk.gov.justice.digital.hmpps.keyworker.dto.StaffSearchRequest
 import uk.gov.justice.digital.hmpps.keyworker.dto.StaffSearchResponse
@@ -29,11 +32,15 @@ import uk.gov.justice.digital.hmpps.keyworker.dto.StaffStatus
 import uk.gov.justice.digital.hmpps.keyworker.dto.StaffSummary
 import uk.gov.justice.digital.hmpps.keyworker.dto.StaffWithRole
 import uk.gov.justice.digital.hmpps.keyworker.integration.PrisonApiClient
+import uk.gov.justice.digital.hmpps.keyworker.integration.casenotes.CaseNoteSummary
 import uk.gov.justice.digital.hmpps.keyworker.integration.casenotes.CaseNotesApiClient
 import uk.gov.justice.digital.hmpps.keyworker.integration.casenotes.NoteUsageResponse
 import uk.gov.justice.digital.hmpps.keyworker.integration.casenotes.UsageByAuthorIdRequest.Companion.lastMonthEntries
 import uk.gov.justice.digital.hmpps.keyworker.integration.casenotes.UsageByAuthorIdRequest.Companion.lastMonthSessions
 import uk.gov.justice.digital.hmpps.keyworker.integration.casenotes.UsageByAuthorIdResponse
+import uk.gov.justice.digital.hmpps.keyworker.integration.casenotes.UsageByPersonIdentifierRequest.Companion.keyworkerTypes
+import uk.gov.justice.digital.hmpps.keyworker.integration.casenotes.UsageByPersonIdentifierRequest.Companion.personalOfficerTypes
+import uk.gov.justice.digital.hmpps.keyworker.integration.casenotes.summary
 import uk.gov.justice.digital.hmpps.keyworker.integration.nomisuserroles.NomisUserRolesApiClient
 
 @Service
@@ -42,6 +49,7 @@ class StaffSearch(
   private val prisonApi: PrisonApiClient,
   private val caseNoteApi: CaseNotesApiClient,
   private val staffRoleRepository: StaffRoleRepository,
+  private val allocationRepository: StaffAllocationRepository,
   private val prisonConfigRepository: PrisonConfigurationRepository,
   private val staffConfigRepository: StaffConfigRepository,
   private val referenceDataRepository: ReferenceDataRepository,
@@ -121,23 +129,60 @@ class StaffSearch(
     prisonCode: String,
     request: AllocatableSearchRequest,
   ): AllocatableSearchResponse {
-    val policy = AllocationContext.get().policy
+    val context = AllocationContext.get()
+    val reportingPeriod = ReportingPeriod.currentMonth()
+
+    val prisonConfig = prisonConfigRepository.findByCode(prisonCode) ?: PrisonConfiguration.default(prisonCode)
 
     val staffMembers =
       findAllocatableStaff(prisonCode)
         .filter { it.staffMember.matches(request.query) }
         .associateBy { it.staffMember.staffId }
 
-    val staffIdStrings = staffMembers.keys.map { it.toString() }.toSet()
-
-    val sessions =
-      when (policy) {
-        AllocationPolicy.KEY_WORKER -> caseNoteApi.getUsageByStaffIds(lastMonthSessions(staffIdStrings))
-        else -> NoteUsageResponse(emptyMap())
+    val applicableAllocationsByStaff =
+      staffMembers.keys.associateWith {
+        allocationRepository
+          .findActiveForPrisonStaffBetween(
+            prisonCode,
+            it,
+            reportingPeriod.from,
+            reportingPeriod.to,
+          ).filter {
+            (it.deallocatedAt == null || !it.deallocatedAt!!.isBefore(reportingPeriod.from)) &&
+              it.allocatedAt.isBefore(reportingPeriod.to)
+          }
       }
-    val entries = caseNoteApi.getUsageByStaffIds(lastMonthEntries(staffIdStrings))
 
-    val prisonConfig = prisonConfigRepository.findByCode(prisonCode) ?: PrisonConfiguration.default(prisonCode)
+    val caseNotesRequest =
+      applicableAllocationsByStaff.entries.filter { it.value.isNotEmpty() }.map {
+        val authorIds = setOf(it.key.toString())
+        val personalIdentifiers = it.value.map { allocation -> allocation.personIdentifier }.toSet()
+
+        if (context.policy == AllocationPolicy.KEY_WORKER) {
+          keyworkerTypes(prisonConfig.code, personalIdentifiers, reportingPeriod.from, reportingPeriod.to, authorIds)
+        } else {
+          personalOfficerTypes(
+            prisonConfig.code,
+            personalIdentifiers,
+            reportingPeriod.from,
+            reportingPeriod.to,
+            authorIds,
+          )
+        }
+      }
+
+    val cnSummaryByStaff =
+      caseNoteApi
+        .getUsageByPersonIdentifiers(caseNotesRequest)
+        .associate {
+          Pair(
+            it.first.authorIds
+              .first()
+              .toLong(),
+            it.second.summary(),
+          )
+        }
+
     val staffDetail =
       if (staffMembers.keys.isEmpty()) {
         emptyMap()
@@ -150,9 +195,10 @@ class StaffSearch(
         .map {
           it.allocatableSummary(
             prisonConfig,
+            reportingPeriod,
             { staffId -> staffDetail[staffId] },
-            { staffId -> sessions.content[staffId.toString()]?.firstOrNull() },
-            { staffId -> entries.content[staffId.toString()]?.firstOrNull() },
+            { staffId -> applicableAllocationsByStaff[staffId].orEmpty() },
+            { staffId -> cnSummaryByStaff[staffId] },
             lazy { referenceDataRepository.findByKey(ReferenceDataDomain.STAFF_STATUS of StaffStatus.ACTIVE.name)!! },
           )
         }.filter { ss -> (request.status == StaffStatus.ALL || request.status.name == ss.status.code) },
@@ -223,9 +269,10 @@ class StaffSearch(
 
   private fun AllocatableStaff.allocatableSummary(
     prisonConfig: PrisonConfiguration,
+    reportingPeriod: ReportingPeriod,
     staffConfig: (Long) -> StaffWithAllocationCount?,
-    sessions: (Long) -> UsageByAuthorIdResponse?,
-    entries: (Long) -> UsageByAuthorIdResponse?,
+    applicableAllocations: (Long) -> List<Allocation>,
+    cnSummary: (Long) -> CaseNoteSummary?,
     activeStatusProvider: Lazy<ReferenceData>,
   ): AllocatableSummary {
     val config = staffConfig(staffMember.staffId)
@@ -238,9 +285,12 @@ class StaffSearch(
       config?.staffConfig?.capacity ?: prisonConfig.capacity,
       config?.allocationCount ?: 0,
       config?.staffConfig?.allowAutoAllocation ?: prisonConfig.allowAutoAllocation,
-      sessions(staffMember.staffId)?.count ?: 0,
-      entries(staffMember.staffId)?.count ?: 0,
       staffRole,
+      applicableAllocations(staffMember.staffId).staffCountStatsFromApplicableAllocations(
+        reportingPeriod,
+        prisonConfig,
+        cnSummary(staffMember.staffId),
+      ),
     )
   }
 }

--- a/src/test/java/uk/gov/justice/digital/hmpps/keyworker/integration/AllocatableStaffSearchIntegrationTest.kt
+++ b/src/test/java/uk/gov/justice/digital/hmpps/keyworker/integration/AllocatableStaffSearchIntegrationTest.kt
@@ -14,6 +14,8 @@ import uk.gov.justice.digital.hmpps.keyworker.domain.StaffConfiguration
 import uk.gov.justice.digital.hmpps.keyworker.dto.AllocatableSearchRequest
 import uk.gov.justice.digital.hmpps.keyworker.dto.AllocatableSearchResponse
 import uk.gov.justice.digital.hmpps.keyworker.dto.CodedDescription
+import uk.gov.justice.digital.hmpps.keyworker.dto.RecordedEventType
+import uk.gov.justice.digital.hmpps.keyworker.dto.ReportingPeriod
 import uk.gov.justice.digital.hmpps.keyworker.dto.StaffLocationRoleDto
 import uk.gov.justice.digital.hmpps.keyworker.dto.StaffRoleInfo
 import uk.gov.justice.digital.hmpps.keyworker.dto.StaffStatus
@@ -21,9 +23,9 @@ import uk.gov.justice.digital.hmpps.keyworker.dto.StaffSummary
 import uk.gov.justice.digital.hmpps.keyworker.integration.casenotes.CaseNote.Companion.KW_SESSION_SUBTYPE
 import uk.gov.justice.digital.hmpps.keyworker.integration.casenotes.CaseNote.Companion.KW_TYPE
 import uk.gov.justice.digital.hmpps.keyworker.integration.casenotes.NoteUsageResponse
-import uk.gov.justice.digital.hmpps.keyworker.integration.casenotes.UsageByAuthorIdRequest.Companion.lastMonthEntries
-import uk.gov.justice.digital.hmpps.keyworker.integration.casenotes.UsageByAuthorIdRequest.Companion.lastMonthSessions
-import uk.gov.justice.digital.hmpps.keyworker.integration.casenotes.UsageByAuthorIdResponse
+import uk.gov.justice.digital.hmpps.keyworker.integration.casenotes.UsageByPersonIdentifierRequest.Companion.keyworkerTypes
+import uk.gov.justice.digital.hmpps.keyworker.integration.casenotes.UsageByPersonIdentifierRequest.Companion.personalOfficerTypes
+import uk.gov.justice.digital.hmpps.keyworker.integration.casenotes.UsageByPersonIdentifierResponse
 import uk.gov.justice.digital.hmpps.keyworker.model.AllocationType
 import uk.gov.justice.digital.hmpps.keyworker.model.StaffStatus.ACTIVE
 import uk.gov.justice.digital.hmpps.keyworker.model.StaffStatus.INACTIVE
@@ -32,6 +34,7 @@ import uk.gov.justice.digital.hmpps.keyworker.utils.NomisIdGenerator.personIdent
 import uk.gov.justice.digital.hmpps.keyworker.utils.NomisStaffGenerator.staffRoles
 import java.math.BigDecimal
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 class AllocatableStaffSearchIntegrationTest : IntegrationTest() {
   @Test
@@ -83,52 +86,20 @@ class AllocatableStaffSearchIntegrationTest : IntegrationTest() {
     staffConfigs
       .mapIndexed { index, kw ->
         (0..index).map {
+          val personIdentifier = personIdentifier()
           givenAllocation(
             staffAllocation(
-              personIdentifier(),
+              personIdentifier,
               prisonCode,
               kw.staffId,
+              allocatedAt = LocalDateTime.now().minusMonths(1),
               allocationType = if (index == 7 && it == 7) AllocationType.PROVISIONAL else AllocationType.AUTO,
             ),
           )
+          personIdentifier
+          kw.mockCaseNotesResponse(policy, prisonCode, ReportingPeriod.currentMonth(), personIdentifier, index)
         }
       }.flatten()
-
-    if (policy == AllocationPolicy.KEY_WORKER) {
-      val sessionUsage =
-        NoteUsageResponse(
-          staffIds
-            .mapIndexed { index, staffId ->
-              UsageByAuthorIdResponse(
-                staffId.toString(),
-                KW_TYPE,
-                KW_SESSION_SUBTYPE,
-                index,
-              )
-            }.groupBy { it.authorId },
-        )
-      caseNotesMockServer.stubUsageByStaffIds(
-        request = lastMonthSessions(staffIds.map(Long::toString).toSet()),
-        response = sessionUsage,
-      )
-    }
-
-    val entryUsage =
-      NoteUsageResponse(
-        staffIds
-          .mapIndexed { index, staffId ->
-            UsageByAuthorIdResponse(
-              staffId.toString(),
-              policy.entryConfig.type,
-              policy.entryConfig.subType,
-              index / 2,
-            )
-          }.groupBy { it.authorId },
-      )
-    caseNotesMockServer.stubUsageByStaffIds(
-      request = lastMonthEntries(staffIds.map(Long::toString).toSet()),
-      response = entryUsage,
-    )
 
     val response =
       searchStaffSpec(prisonCode, request, policy)
@@ -143,28 +114,76 @@ class AllocatableStaffSearchIntegrationTest : IntegrationTest() {
     assertThat(response.content[0].staffId).isEqualTo(staffIds[0])
     assertThat(response.content[0].allowAutoAllocation).isEqualTo(false)
     assertThat(response.content[0].allocated).isEqualTo(0)
-    assertThat(response.content[0].numberOfSessions).isEqualTo(0)
-    assertThat(response.content[0].numberOfEntries).isEqualTo(0)
+    assertThat(
+      response.content[0]
+        .stats.recordedEvents
+        .find { it.type == RecordedEventType.SESSION }
+        ?.count,
+    ).isNull()
+    assertThat(
+      response.content[0]
+        .stats.recordedEvents
+        .find { it.type == RecordedEventType.ENTRY }
+        ?.count,
+    ).isEqualTo(0)
 
     assertThat(response.content.find { it.staffId == staffIds[3] }).isNull()
 
     assertThat(response.content[4].staffId).isEqualTo(staffIds[5])
     assertThat(response.content[4].allowAutoAllocation).isEqualTo(false)
     assertThat(response.content[4].allocated).isEqualTo(0)
-    assertThat(response.content[4].numberOfSessions).isEqualTo(if (policy == AllocationPolicy.KEY_WORKER) 5 else 0)
-    assertThat(response.content[4].numberOfEntries).isEqualTo(2)
+    assertThat(
+      response.content[4]
+        .stats.recordedEvents
+        .find { it.type == RecordedEventType.SESSION }
+        ?.count,
+    ).isEqualTo(
+      if (policy ==
+        AllocationPolicy.KEY_WORKER
+      ) {
+        5
+      } else {
+        null
+      },
+    )
+    assertThat(
+      response.content[4]
+        .stats.recordedEvents
+        .find { it.type == RecordedEventType.ENTRY }
+        ?.count,
+    ).isEqualTo(0)
 
     assertThat(response.content[6].staffId).isEqualTo(staffIds[8])
     assertThat(response.content[6].allowAutoAllocation).isEqualTo(true)
     assertThat(response.content[6].allocated).isEqualTo(7)
-    assertThat(response.content[6].numberOfSessions).isEqualTo(if (policy == AllocationPolicy.KEY_WORKER) 8 else 0)
-    assertThat(response.content[6].numberOfEntries).isEqualTo(4)
+    assertThat(
+      response.content[6]
+        .stats.recordedEvents
+        .find { it.type == RecordedEventType.SESSION }
+        ?.count,
+    ).isEqualTo(
+      if (policy ==
+        AllocationPolicy.KEY_WORKER
+      ) {
+        8
+      } else {
+        null
+      },
+    )
+    assertThat(
+      response.content[6]
+        .stats.recordedEvents
+        .find { it.type == RecordedEventType.ENTRY }
+        ?.count,
+    ).isEqualTo(3)
   }
 
   @ParameterizedTest
   @MethodSource("policyProvider")
   fun `can find all staff with config and counts`(policy: AllocationPolicy) {
     setContext(AllocationContext.get().copy(policy = policy))
+
+    val currentMonth = ReportingPeriod.currentMonth()
 
     val prisonCode = "ATA"
     givenPrisonConfig(prisonConfig(prisonCode, policy = policy))
@@ -192,52 +211,18 @@ class AllocatableStaffSearchIntegrationTest : IntegrationTest() {
     staffConfigs
       .mapIndexed { index, kw ->
         (0..index).map {
+          val personIdentifier = personIdentifier()
           givenAllocation(
             staffAllocation(
-              personIdentifier(),
+              personIdentifier,
               prisonCode,
               kw.staffId,
               allocationType = if (index == 7 && it == 7) AllocationType.PROVISIONAL else AllocationType.AUTO,
             ),
           )
+          kw.mockCaseNotesResponse(policy, prisonCode, currentMonth, personIdentifier, index)
         }
       }.flatten()
-
-    if (policy == AllocationPolicy.KEY_WORKER) {
-      val sessionUsage =
-        NoteUsageResponse(
-          staffIds
-            .mapIndexed { index, staffId ->
-              UsageByAuthorIdResponse(
-                staffId.toString(),
-                KW_TYPE,
-                KW_SESSION_SUBTYPE,
-                index,
-              )
-            }.groupBy { it.authorId },
-        )
-      caseNotesMockServer.stubUsageByStaffIds(
-        request = lastMonthSessions(staffIds.map(Long::toString).toSet()),
-        response = sessionUsage,
-      )
-    }
-
-    val entryUsage =
-      NoteUsageResponse(
-        staffIds
-          .mapIndexed { index, staffId ->
-            UsageByAuthorIdResponse(
-              staffId.toString(),
-              policy.entryConfig.type,
-              policy.entryConfig.subType,
-              index / 2,
-            )
-          }.groupBy { it.authorId },
-      )
-    caseNotesMockServer.stubUsageByStaffIds(
-      request = lastMonthEntries(staffIds.map(Long::toString).toSet()),
-      response = entryUsage,
-    )
 
     val response =
       searchStaffSpec(prisonCode, request, policy)
@@ -289,39 +274,52 @@ class AllocatableStaffSearchIntegrationTest : IntegrationTest() {
       )
     }
 
-    givenAllocation(staffAllocation(personIdentifier(), prisonCode, staffId))
-    givenAllocation(staffAllocation(personIdentifier(), prisonCode, staffId))
+    val personIdentifier = personIdentifier()
+    givenAllocation(staffAllocation(personIdentifier, prisonCode, staffId))
 
-    if (policy == AllocationPolicy.KEY_WORKER) {
-      val sessionUsage =
-        NoteUsageResponse(
-          mapOf(
-            "$staffId" to listOf(UsageByAuthorIdResponse("$staffId", KW_TYPE, KW_SESSION_SUBTYPE, 7)),
-          ),
+    val reportingPeriod = ReportingPeriod.currentMonth()
+
+    caseNotesMockServer.stubUsageByPersonIdentifier(
+      if (policy == AllocationPolicy.KEY_WORKER) {
+        keyworkerTypes(prisonCode, setOf(personIdentifier), reportingPeriod.from, reportingPeriod.to, setOf(staffId.toString()))
+      } else {
+        personalOfficerTypes(
+          prisonCode,
+          setOf(personIdentifier),
+          reportingPeriod.from,
+          reportingPeriod.to,
+          setOf(staffId.toString()),
         )
-      caseNotesMockServer.stubUsageByStaffIds(
-        request = lastMonthSessions(setOf("$staffId")),
-        response = sessionUsage,
-      )
-    }
-
-    val entryUsage =
+      },
       NoteUsageResponse(
-        mapOf(
-          "$staffId" to
+        (
+          if (policy == AllocationPolicy.KEY_WORKER) {
             listOf(
-              UsageByAuthorIdResponse(
-                "$staffId",
+              UsageByPersonIdentifierResponse(
+                personIdentifier,
+                KW_TYPE,
+                KW_SESSION_SUBTYPE,
+                7,
+              ),
+              UsageByPersonIdentifierResponse(
+                personIdentifier,
                 policy.entryConfig.type,
                 policy.entryConfig.subType,
                 3,
               ),
-            ),
-        ),
-      )
-    caseNotesMockServer.stubUsageByStaffIds(
-      request = lastMonthEntries(setOf("$staffId")),
-      response = entryUsage,
+            )
+          } else {
+            listOf(
+              UsageByPersonIdentifierResponse(
+                personIdentifier,
+                policy.entryConfig.type,
+                policy.entryConfig.subType,
+                3,
+              ),
+            )
+          }
+        ).groupBy { it.personIdentifier },
+      ),
     )
 
     val response =
@@ -334,9 +332,25 @@ class AllocatableStaffSearchIntegrationTest : IntegrationTest() {
 
     val staff = response.content.single()
     assertThat(staff.capacity).isEqualTo(6)
-    assertThat(staff.allocated).isEqualTo(2)
-    assertThat(staff.numberOfSessions).isEqualTo(if (policy == AllocationPolicy.KEY_WORKER) 7 else 0)
-    assertThat(staff.numberOfEntries).isEqualTo(3)
+    assertThat(staff.allocated).isEqualTo(1)
+    assertThat(
+      staff.stats.recordedEvents
+        .find { it.type == RecordedEventType.SESSION }
+        ?.count,
+    ).isEqualTo(
+      if (policy ==
+        AllocationPolicy.KEY_WORKER
+      ) {
+        7
+      } else {
+        null
+      },
+    )
+    assertThat(
+      staff.stats.recordedEvents
+        .find { it.type == RecordedEventType.ENTRY }
+        ?.count,
+    ).isEqualTo(3)
     assertThat(staff.staffRole).isEqualTo(
       StaffRoleInfo(
         CodedDescription("PRO", "Prison Officer"),
@@ -381,54 +395,20 @@ class AllocatableStaffSearchIntegrationTest : IntegrationTest() {
     staffConfigs
       .mapIndexed { index, s ->
         (0..index).map {
+          val personIdentifier = personIdentifier()
           givenAllocation(
             staffAllocation(
-              personIdentifier(),
+              personIdentifier,
               prisonCode,
               s.staffId,
               allocationType = AllocationType.MANUAL,
             ),
           )
+          s.mockCaseNotesResponse(policy, prisonCode, ReportingPeriod.currentMonth(), personIdentifier, index)
         }
       }.flatten()
 
     val request = searchRequest("John Smith")
-    val caseNoteStaffIds = staffIds.filter { si[it] == 0 || si[it] == 4 }.map(Long::toString).toSet()
-    if (policy == AllocationPolicy.KEY_WORKER) {
-      val sessionUsage =
-        NoteUsageResponse(
-          staffIds
-            .mapIndexed { index, staffId ->
-              UsageByAuthorIdResponse(
-                staffId.toString(),
-                KW_TYPE,
-                KW_SESSION_SUBTYPE,
-                index,
-              )
-            }.groupBy { it.authorId },
-        )
-      caseNotesMockServer.stubUsageByStaffIds(
-        request = lastMonthSessions(caseNoteStaffIds),
-        response = sessionUsage,
-      )
-    }
-
-    val entryUsage =
-      NoteUsageResponse(
-        staffIds
-          .mapIndexed { index, staffId ->
-            UsageByAuthorIdResponse(
-              staffId.toString(),
-              policy.entryConfig.type,
-              policy.entryConfig.subType,
-              index / 2,
-            )
-          }.groupBy { it.authorId },
-      )
-    caseNotesMockServer.stubUsageByStaffIds(
-      request = lastMonthEntries(caseNoteStaffIds),
-      response = entryUsage,
-    )
 
     val res =
       searchStaffSpec(prisonCode, request, policy)
@@ -458,6 +438,55 @@ class AllocatableStaffSearchIntegrationTest : IntegrationTest() {
     .headers(setHeaders(username = "keyworker-ui", roles = listOfNotNull(role)))
     .header(PolicyHeader.NAME, policy.name)
     .exchange()
+
+  private fun StaffConfiguration.mockCaseNotesResponse(
+    policy: AllocationPolicy,
+    prisonCode: String,
+    reportingPeriod: ReportingPeriod,
+    personIdentifier: String,
+    index: Int,
+  ) = caseNotesMockServer.stubUsageByPersonIdentifier(
+    if (policy == AllocationPolicy.KEY_WORKER) {
+      keyworkerTypes(prisonCode, setOf(personIdentifier), reportingPeriod.from, reportingPeriod.to, setOf(staffId.toString()))
+    } else {
+      personalOfficerTypes(
+        prisonCode,
+        setOf(personIdentifier),
+        reportingPeriod.from,
+        reportingPeriod.to,
+        setOf(staffId.toString()),
+      )
+    },
+    NoteUsageResponse(
+      (
+        if (policy == AllocationPolicy.KEY_WORKER) {
+          listOf(
+            UsageByPersonIdentifierResponse(
+              personIdentifier,
+              KW_TYPE,
+              KW_SESSION_SUBTYPE,
+              index,
+            ),
+            UsageByPersonIdentifierResponse(
+              personIdentifier,
+              policy.entryConfig.type,
+              policy.entryConfig.subType,
+              index / 2,
+            ),
+          )
+        } else {
+          listOf(
+            UsageByPersonIdentifierResponse(
+              personIdentifier,
+              policy.entryConfig.type,
+              policy.entryConfig.subType,
+              index / 2,
+            ),
+          )
+        }
+      ).groupBy { it.personIdentifier },
+    ),
+  )
 
   companion object {
     const val SEARCH_URL = "/search/prisons/{prisonCode}/staff-allocations"

--- a/src/test/java/uk/gov/justice/digital/hmpps/keyworker/integration/AllocatableStaffSearchIntegrationTest.kt
+++ b/src/test/java/uk/gov/justice/digital/hmpps/keyworker/integration/AllocatableStaffSearchIntegrationTest.kt
@@ -131,7 +131,15 @@ class AllocatableStaffSearchIntegrationTest : IntegrationTest() {
         .stats.recordedEvents
         .find { it.type == RecordedEventType.SESSION }
         ?.count,
-    ).isNull()
+    ).isEqualTo(
+      if (policy ==
+        AllocationPolicy.KEY_WORKER
+      ) {
+        0
+      } else {
+        null
+      },
+    )
     assertThat(
       response.content[0]
         .stats.recordedEvents


### PR DESCRIPTION
MIA-516 add stats to `POST /search/prisons/{prisonCode}/staff-allocations` endpoint