### PR TITLE
Merge events should not affect case notes

### DIFF
--- a/src/main/java/uk/gov/justice/digital/hmpps/keyworker/services/AllocationCaseNoteService.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/keyworker/services/AllocationCaseNoteService.kt
@@ -9,7 +9,6 @@ import uk.gov.justice.digital.hmpps.keyworker.integration.casenotes.CaseNotesApi
 import uk.gov.justice.digital.hmpps.keyworker.integration.casenotes.CaseNotesOfInterest
 import uk.gov.justice.digital.hmpps.keyworker.integration.casenotes.asAllocationCaseNote
 import uk.gov.justice.digital.hmpps.keyworker.integration.events.CaseNoteInformation
-import uk.gov.justice.digital.hmpps.keyworker.integration.events.MergeInformation
 
 @Transactional
 @Service
@@ -38,17 +37,6 @@ class AllocationCaseNoteService(
 
   private fun getCaseNote(personInformation: PersonInformation): CaseNote? =
     caseNoteApi.getCaseNote(personInformation.personIdentifier, personInformation.info.id)
-
-  fun merge(mergeInfo: MergeInformation) {
-    caseNoteRepository.deleteAllByPersonIdentifier(mergeInfo.removedNomsNumber)
-    caseNoteRepository.flush()
-    val caseNotes =
-      caseNoteApi
-        .getCaseNotesOfInterest(mergeInfo.nomsNumber)
-        .content
-        .map { it.asAllocationCaseNote() }
-    caseNoteRepository.saveAll(caseNotes)
-  }
 }
 
 data class PersonInformation(

--- a/src/main/java/uk/gov/justice/digital/hmpps/keyworker/services/MergePrisonNumbers.kt
+++ b/src/main/java/uk/gov/justice/digital/hmpps/keyworker/services/MergePrisonNumbers.kt
@@ -29,6 +29,5 @@ class MergePrisonNumbers(
         }
       }
     allocationRepository.saveAll(allocations)
-    caseNoteService.merge(mergeInformation)
   }
 }

--- a/src/test/java/uk/gov/justice/digital/hmpps/keyworker/integration/MergePrisonerIntTest.kt
+++ b/src/test/java/uk/gov/justice/digital/hmpps/keyworker/integration/MergePrisonerIntTest.kt
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.keyworker.config.AllocationContext
 import uk.gov.justice.digital.hmpps.keyworker.domain.Allocation
-import uk.gov.justice.digital.hmpps.keyworker.domain.AllocationCaseNote
 import uk.gov.justice.digital.hmpps.keyworker.integration.casenotes.CaseNote
 import uk.gov.justice.digital.hmpps.keyworker.integration.casenotes.CaseNote.Companion.KW_SESSION_SUBTYPE
 import uk.gov.justice.digital.hmpps.keyworker.integration.casenotes.CaseNote.Companion.KW_TYPE
@@ -58,9 +57,8 @@ class MergePrisonerIntTest : IntegrationTest() {
     val merged = requireNotNull(allocationRepository.findByIdOrNull(alloc.id))
     assertThat(merged.personIdentifier).isEqualTo(newNoms)
 
-    val affected = setOf(Allocation::class.simpleName!!, AllocationCaseNote::class.simpleName!!)
+    val affected = setOf(Allocation::class.simpleName!!)
     verifyAudit(merged, merged.id, RevisionType.MOD, affected, AllocationContext.get())
-    verifyAudit(acn, acn.id, RevisionType.MOD, affected, AllocationContext.get())
   }
 
   @Test


### PR DESCRIPTION
case notes will send move events for the appropriate changes