### PR TITLE
LSM-442: Increase Limits

### DIFF
--- a/helm_deploy/keyworker-api/values.yaml
+++ b/helm_deploy/keyworker-api/values.yaml
@@ -27,10 +27,10 @@ generic-service:
   resources:
     requests:
       cpu: 128m
-      memory: 1024Mi
+      memory: 1280Mi
     limits:
       cpu: 2048m
-      memory: 1280Mi
+      memory: 1536Mi
 
   ingress:
     enabled: true


### PR DESCRIPTION
Increase keyworker-api memory limits based on observed ~1.1Gi pod usage